### PR TITLE
Lab 2 - Fix `TypeError: unhashable type: 'collections.OrderedDict'`

### DIFF
--- a/content/lab_2/lab-2.ipynb
+++ b/content/lab_2/lab-2.ipynb
@@ -1017,7 +1017,7 @@
     "ax1.legend(fontsize=10)\n",
     "\n",
     "# Plot 2: Total Number of Gates\n",
-    "ax2.semilogy(ax, [gate_counts[key] for key in ax],'^-',markersize=9, color='#66B2FF', label=\"Counts\")\n",
+    "ax2.semilogy(ax, [sum(gate_counts[key].values()) for key in ax],'^-',markersize=9, color='#66B2FF', label=\"Counts\") \n",
     "ax2.set_xlabel(\"Optimization Level\", fontsize=12)\n",
     "ax2.set_ylabel(\"Gate Count\", fontsize=12)\n",
     "ax2.set_title(\"Gate Count\", fontsize=14)\n",


### PR DESCRIPTION
This PR fixes a bug on `Python 3.12` / `matplotlib==3.9.0` where:
```python3
ax2.semilogy(ax, [gate_counts[key] for key in ax],'^-',markersize=9, color='#66B2FF', label="Counts")
```
results in `TypeError: unhashable type: 'collections.OrderedDict'`